### PR TITLE
feat: Add functionality for max HP damage

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -124,6 +124,7 @@ export interface InitiativeViewState {
 export interface CreatureState extends HomebrewCreature {
     status: string[];
     enabled: boolean;
+    currentMaxHP: number;
     currentHP: number;
     tempHP: number;
     initiative: number;
@@ -204,6 +205,7 @@ export interface UpdateLogMessage {
     name: string;
     hp: number | null;
     temp: boolean;
+    max: boolean;
     status: string | null;
     saved: boolean;
     unc: boolean;

--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ Once all of the creatures in a given combat have been added, initiatives can be 
 
 ### HP
 
-Creatures can take damage, be healed or gain temporary HP by clicking on their HP.
+Creatures can take damage, be healed, gain temporary HP or take max HP damage by clicking on their HP.
+The temp HP and max HP modifiers also support the "-" symbol to remove temp HP and restore/gain max HP.
 
 #### Rolling HP
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "initiative-tracker",
-    "version": "9.5.0",
+    "version": "9.5.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "initiative-tracker",
-            "version": "9.5.0",
+            "version": "9.5.1",
             "license": "MIT",
             "devDependencies": {
-                "@popperjs/core": "^2.9.2",
+                "@popperjs/core": "^2.11.7",
                 "@tsconfig/svelte": "^2.0.1",
                 "@types/node": "^14.14.37",
                 "builtin-modules": "^3.3.0",
@@ -508,9 +508,9 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.7",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+            "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -2518,9 +2518,9 @@
             "dev": true
         },
         "node_modules/json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "optional": true,
             "peer": true,
@@ -4192,9 +4192,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.75.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+            "version": "5.77.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+            "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
             "dev": true,
             "peer": true,
             "dependencies": {
@@ -4782,9 +4782,9 @@
             }
         },
         "@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.7",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
+            "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
             "dev": true
         },
         "@tsconfig/svelte": {
@@ -6285,9 +6285,9 @@
             "dev": true
         },
         "json5": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-            "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "optional": true,
             "peer": true
@@ -7492,9 +7492,9 @@
             }
         },
         "webpack": {
-            "version": "5.75.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-            "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+            "version": "5.77.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+            "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
             "dev": true,
             "peer": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "author": "",
     "license": "MIT",
     "devDependencies": {
-        "@popperjs/core": "^2.9.2",
+        "@popperjs/core": "^2.11.7",
         "@tsconfig/svelte": "^2.0.1",
         "@types/node": "^14.14.37",
         "builtin-modules": "^3.3.0",

--- a/src/tracker/stores/tracker.ts
+++ b/src/tracker/stores/tracker.ts
@@ -129,12 +129,12 @@ function createTracker() {
                     // Handle overflow healing according to settings
                     if (
                         change.hp > 0 &&
-                        change.hp + creature.hp > creature.max
+                        change.hp + creature.hp > creature.current_max
                     ) {
                         switch (_settings.hpOverflow) {
                             case OVERFLOW_TYPE.ignore:
                                 change.hp = Math.max(
-                                    creature.max - creature.hp,
+                                    creature.current_max - creature.hp,
                                     0
                                 );
                                 break;
@@ -142,7 +142,7 @@ function createTracker() {
                                 // Gives temp a value, such that it will be set later
                                 change.temp =
                                     change.hp -
-                                    Math.min(creature.max - creature.hp, 0);
+                                    Math.min(creature.current_max - creature.hp, 0);
                                 change.hp -= change.temp;
                                 break;
                             case OVERFLOW_TYPE.current:
@@ -159,10 +159,10 @@ function createTracker() {
                     }
                 }
                 if (change.max) {
-                    if (creature.hp == creature.max) {
-                        creature.hp = Number(change.max);
+                    creature.current_max = Math.max(0, creature.current_max + change.max);
+                    if (creature.hp >= creature.current_max && _settings.hpOverflow !== OVERFLOW_TYPE.current) {
+                        creature.hp = creature.current_max;
                     }
-                    creature.max = Number(change.max);
                 }
                 if (change.ac) {
                     creature.ac = change.ac;
@@ -172,10 +172,18 @@ function createTracker() {
                     if (_settings.additiveTemp) {
                         baseline = creature.temp;
                     }
-                    creature.temp = Math.max(
-                        creature.temp,
-                        baseline + change.temp
-                    );
+                    if (change.temp > 0) {
+                        creature.temp = Math.max(
+                            creature.temp,
+                            baseline + change.temp
+                        );
+                    }
+                    else {
+                        creature.temp = Math.max(
+                            0,
+                            creature.temp + change.temp
+                        );
+                    };
                 }
                 if (change.marker) {
                     creature.marker = change.marker;
@@ -310,6 +318,7 @@ function createTracker() {
                         name: name.join(" "),
                         hp: null,
                         temp: false,
+                        max: false,
                         status: null,
                         saved: false,
                         unc: false
@@ -321,17 +330,22 @@ function createTracker() {
                         message.temp = true;
                         change.temp = toAdd;
                     } else {
-                        let toAdd = Number(toAddString);
+                        const maxHpDamage = toAddString.charAt(0) === "m";
+                        let toAdd = Number(toAddString.slice(+maxHpDamage));
                         toAdd =
                             -1 *
                             Math.sign(toAdd) *
                             Math.max(Math.abs(toAdd) * modifier, 1);
                         toAdd = roundHalf ? Math.trunc(toAdd) : toAdd;
                         message.hp = toAdd;
+                        if (maxHpDamage) {
+                            message.max = true;
+                            change.max = toAdd;
+                        }
+                        change.hp = toAdd;
                         if (creature.hp <= 0) {
                             message.unc = true;
                         }
-                        change.hp = toAdd;
                     }
                     if (tag) {
                         message.status = tag.name;
@@ -457,7 +471,7 @@ function createTracker() {
                         let roller = plugin.getRoller(
                             creature.hit_dice
                         ) as StackRoller;
-                        creature.hp = creature.max = roller.rollSync();
+                        creature.hp = creature.max = creature.current_max = roller.rollSync();
                     }
                 }
                 creatures.push(...items);
@@ -522,7 +536,7 @@ function createTracker() {
                             let roller = plugin.getRoller(
                                 creature.hit_dice
                             ) as StackRoller;
-                            creature.hp = creature.max = roller.rollSync();
+                            creature.hp = creature.max = creature.current_max = roller.rollSync();
                         }
                     }
                 }
@@ -541,7 +555,7 @@ function createTracker() {
         reset: () =>
             updateAndSave((creatures) => {
                 for (let creature of creatures) {
-                    creature.hp = creature.max;
+                    creature.hp = creature.current_max = creature.max;
                     creature.enabled = true;
                     creature.hidden = false;
                     creature.status.clear();
@@ -563,22 +577,44 @@ function createTracker() {
                                 message.name
                             } gained ${message.hp.toString()} temporary HP`
                         );
-                    } else if (message.hp < 0) {
-                        perCreature.push(
-                            `${message.name} took ${(
-                                -1 * message.hp
-                            ).toString()} damage${
-                                message.unc
-                                    ? " and was knocked unconscious"
-                                    : ""
-                            }`
-                        );
-                    } else if (message.hp > 0) {
-                        perCreature.push(
-                            `${
-                                message.name
-                            } was healed for ${message.hp.toString()} HP`
-                        );
+                    } else if (!message.max) {
+                        if (message.hp < 0) {
+                            perCreature.push(
+                                `${message.name} took ${(
+                                    -1 * message.hp
+                                ).toString()} damage${
+                                    message.unc
+                                        ? " and was knocked unconscious"
+                                        : ""
+                                }`
+                            );
+                        } else if (message.hp > 0) {
+                            perCreature.push(
+                                `${
+                                    message.name
+                                } was healed for ${message.hp.toString()} HP`
+                            );
+                        }
+                    }
+                     else if (message.max) {
+                        if (message.hp < 0) {
+                            perCreature.push(
+                                `${message.name} took ${(
+                                    -1 * message.hp
+                                ).toString()} max HP damage${
+                                    message.unc
+                                        ? " and died"
+                                        : ""
+                                }`
+                            );
+                        }
+                        else {
+                            perCreature.push(
+                                `${message.name} gained ${(
+                                    -1 * message.hp
+                                ).toString()} max HP`
+                            );
+                        }
                     }
                 }
                 if (message.status) {

--- a/src/tracker/ui/Updating.svelte
+++ b/src/tracker/ui/Updating.svelte
@@ -59,13 +59,13 @@
             <div class="hp-status">
                 {#if plugin.data.beginnerTips}
                     <small class="label">
-                        Apply damage, healing(-) or temp HP(t)
+                        Apply damage, (m)max HP damage, (-)healing or (t)temp HP
                     </small>
                 {/if}
                 <div class="input">
                     <tag
                         use:hpIcon
-                        aria-label="Apply damage, healing(-) or temp HP(t)"
+                        aria-label="Apply damage, (m)max HP damage, (-)healing or (t)temp HP"
                         style="margin: 0 0.2rem 0 0.7rem"
                     />
                     <input
@@ -80,7 +80,7 @@
                                 return;
                             }
                             if (
-                                !/^(t?-?\d*\.?\d*(Backspace|Delete|Arrow\w+)?)$/.test(
+                                !/^((t|m)?-?\d*\.?\d*(Backspace|Delete|Arrow\w+)?)$/.test(
                                     this.value + evt.key
                                 )
                             ) {

--- a/src/tracker/ui/create/Creator.svelte
+++ b/src/tracker/ui/create/Creator.svelte
@@ -35,7 +35,7 @@
                 if (!$adding.length && !isEditing) return;
                 if (isEditing) {
                     if ($editing.hp != creature.max) {
-                        creature.max = $editing.hp;
+                        creature.max = creature.current_max = $editing.hp;
                     }
                     tracker.replace(creature, $editing);
                 } else {

--- a/src/tracker/ui/creatures/Table.svelte
+++ b/src/tracker/ui/creatures/Table.svelte
@@ -82,7 +82,7 @@
                     class:friendly={creature.friendly}
                     animate:flip={{ duration: flipDurationMs }}
                     data-hp={creature.hp}
-                    data-hp-max={creature.max}
+                    data-hp-max={creature.current_max}
                     data-hp-percent={Math.round(
                         ((creature.hp ?? 0) / creature.max) * 100 ?? 0
                     )}

--- a/src/utils/creature.ts
+++ b/src/utils/creature.ts
@@ -27,6 +27,7 @@ export class Creature {
     enabled: boolean = true;
     hidden: boolean = false;
     max: number;
+    current_max: number;
     level: number;
     player: boolean;
     status: Set<Condition> = new Set();
@@ -50,7 +51,7 @@ export class Creature {
                 : Number(initiative ?? 0);
         this.modifier = Number(creature.modifier ?? 0);
 
-        this.max = creature.hp ? Number(creature.hp) : undefined;
+        this.max = this.current_max = creature.hp ? Number(creature.hp) : 0;
         this.ac = creature.ac ?? undefined;
         this.note = creature.note;
         this.level = creature.level;
@@ -84,14 +85,14 @@ export class Creature {
         }
     }
     get hpDisplay() {
-        if (this.max) {
+        if (this.current_max) {
             const tempMods =
                 this.temp > 0
                     ? `aria-label="Temp HP: ${this.temp}" style="font-weight:bold"`
                     : "";
             return `
                 <span ${tempMods}>${this.hp + this.temp}</span><span>/${
-                this.max
+                this.current_max
             }</span>
             `;
         }
@@ -169,7 +170,7 @@ export class Creature {
         this.name = creature.name;
         this.modifier = Number(creature.modifier ?? 0);
 
-        this.max = creature.hp ? Number(creature.hp) : undefined;
+        this.current_max = this.max = creature.hp ? Number(creature.hp) : 0;
 
         if (this.hp > this.max) this.hp = this.max;
 
@@ -194,6 +195,7 @@ export class Creature {
             initiative: this.initiative - this.modifier,
             modifier: this.modifier,
             hp: this.max,
+            currentMaxHP: this.current_max,
             ac: this.ac,
             note: this.note,
             id: this.id,
@@ -218,6 +220,7 @@ export class Creature {
         creature.enabled = state.enabled;
 
         creature.temp = state.tempHP ? state.tempHP : 0;
+        creature.current_max = state.currentMaxHP;
         creature.hp = state.currentHP;
         let statuses: Condition[] = [];
         for (const status of state.status) {


### PR DESCRIPTION
Creatures' max HP can take damage and receive healing through the "m" prefix.
creature.current_max is introduced as a variable to ensure resetting the encounter also resets max HP.

The rules for reducing max HP follow the standard rules in 5e:
    Damage to max HP is applied after normal damage.
    Creature HP can't be higher than max HP (rule disabled if overflow healing is enabled).
    Max HP has a lower clamp at 0.

Additionally, temp HP can now be subtracted to remove only the temp HP.
Useful for scenarios such as removing all temp HP from multiple creatures affected by the Heroism spell.

Check-in to: master