### PR TITLE
fix: properly log automatic unconscious status (close #132)

### DIFF
--- a/src/tracker/stores/tracker.ts
+++ b/src/tracker/stores/tracker.ts
@@ -334,7 +334,10 @@ function createTracker() {
                             Math.max(Math.abs(toAdd) * modifier, 1);
                         toAdd = roundHalf ? Math.trunc(toAdd) : toAdd;
                         message.hp = toAdd;
-                        if (creature.hp <= 0) {
+                        if (
+                            toAdd < 0 &&
+                            creature.hp + creature.temp + toAdd <= 0
+                           ) {
                             message.unc = true;
                         }
                         change.hp = toAdd;


### PR DESCRIPTION
The idea is to set the flag for the unconscious status in the message if we know that the update will bring the creature below 0 HPs...