### PR TITLE
fix: handling of status amounts and logging of receiving multiple statuses

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -63,10 +63,12 @@ export type Condition = {
     resetOnRound?: boolean;
     hasAmount?: boolean;
     startingAmount?: number;
+    amount?:number;
 } & (
     | {
           hasAmount: true;
           startingAmount: number;
+          amount: number;
       }
     | {}
 );

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -167,7 +167,7 @@ export default class Logger {
                 if (message.status.length > 1) {
                     status = [
                         message.status
-                            .slice(0, Math.min(message.status.length - 1, 1))
+                            .slice(0, Math.max(message.status.length - 1, 1))
                             .join(", ")
                     ];
                     status.push(message.status[message.status.length - 1]);

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1474,7 +1474,7 @@ class StatusModal extends Modal {
                         (t
                             .setValue(`${this.status.startingAmount}`)
                             .onChange((v) => {
-                                this.status.startingAmount = Number(v);
+                                this.status.amount = this.status.startingAmount = Number(v);
                             }).inputEl.type = "number")
                 );
         }

--- a/src/tracker/ui/creatures/Status.svelte
+++ b/src/tracker/ui/creatures/Status.svelte
@@ -6,7 +6,6 @@
     import type { Condition } from "index";
 
     export let status: Condition;
-    $: amount = status.startingAmount;
     const deleteIcon = (node: HTMLElement) => {
         new ExtraButtonComponent(node).setIcon("cross-in-box");
     };
@@ -31,12 +30,12 @@
                 class="icon"
                 use:minus
                 on:click={() => {
-                    amount--;
-                    if (amount <= 0) dispatch("remove");
+                    status.amount--;
+                    if (status.amount <= 0) dispatch("remove");
                 }}
             />
-            <span>{amount}</span>
-            <div class="icon" use:plus on:click={() => amount++} />
+            <span>{status.amount}</span>
+            <div class="icon" use:plus on:click={() => status.amount++} />
         </div>
     {/if}
     <div use:deleteIcon on:click={() => dispatch("remove")} />


### PR DESCRIPTION
Without this change:

- Any change done to a status' amount would be lost (and the value reset to the starting amount) as soon as the turn advances;
- When multiple statuses are assigned, only 2 were logged, instead of the full list.