### PR TITLE
Creatures not in bestiary now render correctly in Combatant

### DIFF
--- a/src/tracker/view.ts
+++ b/src/tracker/view.ts
@@ -141,8 +141,7 @@ export class CreatureView extends ItemView {
             await this.renderEmbed(creature.getStatblockLink());
         } else if (this.plugin.canUseStatBlocks) {
             const statblock = window.FantasyStatblocks.render(
-                //@ts-ignore
-                creature,
+                creature.creature,
                 this.statblockEl,
                 creature.display
             );


### PR DESCRIPTION
## Pull Request Description

Creatures defined with statblocks inside notes now render correctly in Combatant. Previously, if there was a creature defined with the same name as one in the bestiary, it would override some stats correctly, but not all of them. A custom creature in a note also only rendered the 'initiative tracked' values. 
This probably need a more thorough testing, but everything seems to be working correctly from my tests.

Something this does not resolve, is if you reload obsidian while a custom creature is still in the initiative tracker, it will not rehydrate from the note.

## Changes Proposed

Pass the original creature to the render plugin instead of the 'initiative tracked' creature 

## Related Issues

I think this is related to #193 #javalent/fantasy-statblocks/issues/401

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

### Before
<img width="1389" alt="Before" src="https://github.com/javalent/initiative-tracker/assets/4422185/d7779304-3f43-4aae-b3a7-36fbfa61131d">

### After
<img width="1382" alt="After" src="https://github.com/javalent/initiative-tracker/assets/4422185/a09e401d-d9c6-4ab4-9a9a-1fbca418dc61">

