### PR TITLE
Add initiative ties resolution setting

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -20,7 +20,9 @@ import {
     DEFAULT_UNDEFINED,
     EDIT,
     HP,
-    INITIATIVE
+    INITIATIVE,
+    OVERFLOW_TYPE,
+    RESOLVE_TIES
 } from "../utils";
 import { RpgSystemSetting, getRpgSystem } from "../utils/rpg-system";
 import type { Party } from "./settings.types";
@@ -209,10 +211,10 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                 "Set what happens to healing which goes above creatures' max HP threshold."
             )
             .addDropdown((d) => {
-                d.addOption("ignore", "Ignore");
-                d.addOption("temp", "Add to temp HP");
-                d.addOption("current", "Add to current HP");
-                d.setValue(this.plugin.data.hpOverflow ?? "ignore");
+                d.addOption(OVERFLOW_TYPE.ignore, "Ignore");
+                d.addOption(OVERFLOW_TYPE.temp, "Add to temp HP");
+                d.addOption(OVERFLOW_TYPE.current, "Add to current HP");
+                d.setValue(this.plugin.data.hpOverflow ?? OVERFLOW_TYPE.ignore);
                 d.onChange(async (v) => {
                     this.plugin.data.hpOverflow = v;
                     this.plugin.saveSettings();
@@ -327,6 +329,21 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                     this.plugin.data.logFolder = normalizePath(item.path);
                     await this.plugin.saveSettings();
                     this.display();
+                });
+            });
+            new Setting(additionalContainer)
+            .setName("Resolve Initiative Ties")
+            .setDesc(
+                "Define what happens if two creatures have the same initiative."
+            )
+            .addDropdown((d) => {
+                d.addOption(RESOLVE_TIES.playerFirst, "Player first");
+                d.addOption(RESOLVE_TIES.npcFirst, "NPC first");
+                d.addOption(RESOLVE_TIES.random, "Random");
+                d.setValue(this.plugin.data.resolveTies ?? RESOLVE_TIES.playerFirst);
+                d.onChange(async (v) => {
+                    this.plugin.data.resolveTies = v;
+                    this.plugin.saveSettings();
                 });
             });
     }

--- a/src/settings/settings.types.ts
+++ b/src/settings/settings.types.ts
@@ -39,6 +39,7 @@ export interface InitiativeTrackerData {
     warnedAboutImports: boolean;
     logging: boolean;
     logFolder: string;
+    resolveTies: string;
     useLegacy: boolean;
     diplayPlayerHPValues: boolean;
     rollHP: boolean;

--- a/src/tracker/stores/tracker.ts
+++ b/src/tracker/stores/tracker.ts
@@ -15,6 +15,7 @@ import type { InitiativeTrackerData } from "src/settings/settings.types";
 import type { InitiativeViewState } from "../view.types";
 import {
     OVERFLOW_TYPE,
+    RESOLVE_TIES,
     RollPlayerInitiativeBehavior,
     getRpgSystem
 } from "src/utils";
@@ -116,6 +117,21 @@ function createTracker() {
     const ordered = derived([condensed, data], ([values, data]) => {
         const sort = [...values];
         sort.sort((a, b) => {
+            if (a.initiative == b.initiative) {
+                switch (_settings.resolveTies) {
+                    case RESOLVE_TIES.random:
+                        return Math.random() < 0.5 ? 1 : -1;
+                    case RESOLVE_TIES.playerFirst:
+                    case RESOLVE_TIES.npcFirst:
+                        const aPlayer = a.player ? 1 : 0;
+                        const bPlayer = b.player ? 1 : 0;
+                        if (_settings.resolveTies == RESOLVE_TIES.playerFirst) {
+                            return bPlayer - aPlayer
+                        } else {
+                            return aPlayer - bPlayer
+                        }
+                }
+            }
             return data.descending
                 ? b.initiative - a.initiative
                 : a.initiative - b.initiative;

--- a/src/tracker/stores/tracker.ts
+++ b/src/tracker/stores/tracker.ts
@@ -96,7 +96,7 @@ function createTracker() {
         return data.descending;
     });
     let _settings: InitiativeTrackerData | null;
-
+    
     const condensed = derived(creatures, (values) => {
         if (_settings?.condense) {
             values.forEach((creature, _, arr) => {
@@ -117,24 +117,40 @@ function createTracker() {
     const ordered = derived([condensed, data], ([values, data]) => {
         const sort = [...values];
         sort.sort((a, b) => {
-            if (a.initiative == b.initiative) {
-                switch (_settings.resolveTies) {
-                    case RESOLVE_TIES.random:
-                        return Math.random() < 0.5 ? 1 : -1;
-                    case RESOLVE_TIES.playerFirst:
-                    case RESOLVE_TIES.npcFirst:
-                        const aPlayer = a.player ? 1 : 0;
-                        const bPlayer = b.player ? 1 : 0;
-                        if (_settings.resolveTies == RESOLVE_TIES.playerFirst) {
-                            return bPlayer - aPlayer
-                        } else {
-                            return aPlayer - bPlayer
-                        }
-                }
-            }
-            return data.descending
+            /* Order creatures in this order:
+               1. By initiative
+               2. By manual order (drag & drop)
+               3. According to the resolveTies setting */
+            if (a.initiative != b.initiative) {
+                return data.descending
                 ? b.initiative - a.initiative
                 : a.initiative - b.initiative;
+            }
+            
+            if (
+                a.manualOrder !== null && a.manualOrder !== undefined && 
+                b.manualOrder !== null && b.manualOrder !== undefined && 
+                a.manualOrder !== b.manualOrder
+            ) {
+                const aOrder = a.manualOrder || 0;
+                const bOrder = b.manualOrder || 0;
+                return aOrder - bOrder;
+            }
+            
+            switch (_settings.resolveTies) {
+                case RESOLVE_TIES.random:
+                    return Math.random() < 0.5 ? 1 : -1;
+                case RESOLVE_TIES.playerFirst:
+                case RESOLVE_TIES.npcFirst:
+                    const aPlayer = a.player ? 1 : 0;
+                    const bPlayer = b.player ? 1 : 0;
+                    if (_settings.resolveTies == RESOLVE_TIES.playerFirst) {
+                        return bPlayer - aPlayer
+                    } else {
+                        return aPlayer - bPlayer
+                    }
+            }
+            
         });
         current_order = sort;
         return sort;
@@ -352,6 +368,7 @@ function createTracker() {
                     creature.modifier
                 );
             }
+            creature.manualOrder = null;
         }
         return creatures;
     }

--- a/src/tracker/ui/creatures/Table.svelte
+++ b/src/tracker/ui/creatures/Table.svelte
@@ -54,7 +54,10 @@
             tracker.logNewInitiative(dropped.creature);
         }
         items = e.detail.items;
-        $tracker = [...items.map(({ creature }) => creature)];
+        $tracker = [...items.map(({ creature }, i) => {
+            creature.manualOrder = i;
+            return creature;
+        })];
     }
 
     const diceIcon = (node: HTMLElement) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,6 +18,18 @@ export enum RollPlayerInitiativeBehavior {
     SetToZero
 }
 
+export const OVERFLOW_TYPE: { [key: string]: string } = {
+    ignore: "ignore",
+    current: "current",
+    temp: "temp"
+};
+
+export const RESOLVE_TIES: { [key: string]: string } = {
+    playerFirst: "playerFirst",
+    npcFirst: "npcFirst",
+    random: "random",
+};
+
 export const DEFAULT_SETTINGS: InitiativeTrackerData = {
     players: [],
     parties: [],
@@ -54,11 +66,12 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
         player: true,
         builder: true
     },
-    hpOverflow: "ignore",
+    hpOverflow: OVERFLOW_TYPE.ignore,
     additiveTemp: false,
     rpgSystem: "dnd5e",
     logging: false,
     logFolder: "/",
+    resolveTies: RESOLVE_TIES.playerFirst,
     useLegacy: false,
     diplayPlayerHPValues: true,
     rollHP: false,
@@ -69,12 +82,6 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
         sidebarIcon: true
     },
     rollPlayerInitiatives: RollPlayerInitiativeBehavior.Always
-};
-
-export const OVERFLOW_TYPE: { [key: string]: string } = {
-    ignore: "ignore",
-    current: "current",
-    temp: "temp"
 };
 
 export const DECIMAL_TO_VULGAR_FRACTION: Record<string, string> = {

--- a/src/utils/creature.ts
+++ b/src/utils/creature.ts
@@ -35,6 +35,7 @@ export class Creature {
     status: Set<Condition> = new Set();
     marker: string;
     initiative: number;
+    manualOrder: number;
     static: boolean = false;
     source: string | string[];
     id: string;


### PR DESCRIPTION
## Pull Request Description

Add an option to define how initiative ties are resolved.

Default is players first, similar to existing behaviour (not explicitly defined, but players seem to be added to encounters before other creatures). Other options are NPCs first or random.

## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [ ] New option in settings to define how initiative ties are resolved.
- [ ] When creatures are dragged & dropped, ordering index is stored for each creature to override initiative ties setting                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
- [ ] Order of creatures is defined by initiative, then manual order, then initiative ties setting.
- [ ] Dragging creatures outside of their current initiative still changes their initiative, as before
- [ ] Rerolling initiative clears manual ordering and reapplies initiative ties setting
- [ ] Used constants for an existing setting instead of hardcoded strings

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

Fixes #294 by adding an option to make NPCs win initiative ties

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

<!-- If your changes include visual updates, include relevant screenshots here -->

## Additional Notes

<!-- Any additional information or context you want to provide about the pull request -->
