### PR TITLE
Use parseInt when reading PC definitions

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1070,10 +1070,10 @@ class NewPlayerModal extends Modal {
                     const { ac, hp, modifier, level, name } =
                         metaData.frontmatter;
                     this.player.name = name ?? this.player.name;
-                    this.player.ac = ac ?? this.player.ac;
-                    this.player.hp = hp ?? this.player.hp;
-                    this.player.level = level ?? this.player.level;
-                    this.player.modifier = modifier ?? this.player.modifier;
+                    this.player.ac = parseInt(ac ?? this.player.ac, 10);
+                    this.player.hp = parseInt(hp ?? this.player.hp, 10);
+                    this.player.level = parseInt(level ?? this.player.level, 10);
+                    this.player.modifier = parseInt(modifier ?? this.player.modifier, 10);
                     this.player["statblock-link"] =
                         metaData.frontmatter["statblock-link"];
                     this.display();


### PR DESCRIPTION
## Pull Request Description

Avoids failures caused by the user defining frontmatter as a string instead of a number, such as trying to concatenate numbers as strings instead of adding

## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [x] NewPlayerModal calls parseInt() on all player values except name

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

Fixes #291 

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

<!-- If your changes include visual updates, include relevant screenshots here -->

## Additional Notes

<!-- Any additional information or context you want to provide about the pull request -->
