### PR TITLE
Update builder table

### DIFF
--- a/src/builder/builder.types.ts
+++ b/src/builder/builder.types.ts
@@ -13,6 +13,9 @@ export interface BuilderState {
 export enum SortFunctions {
     LOCAL_COMPARE,
     CONVERT_FRACTION,
+    PF2_LEVEL,
+    PF2_TYPE, 
+    PF2_TRAIT,
     CUSTOM
 }
 export type TableHeaderState = {

--- a/src/builder/stores/filter/EditFilter.svelte
+++ b/src/builder/stores/filter/EditFilter.svelte
@@ -30,6 +30,9 @@
             d.addOption(`${FilterType.Range}`, "Range");
             d.addOption(`${FilterType.Options}`, "Options");
             d.addOption(`${FilterType.Search}`, "Search");
+            d.addOption(`${FilterType.PF2_Level_Range}`, "PF2 - Level");
+            d.addOption(`${FilterType.PF2_Creature_Type}`, "PF2 - Monster type");
+            d.addOption(`${FilterType.PF2_Trait}`, "PF2 - Traits");
             d.setValue(`${filter.type}`).onChange((v) => {
                 filter.type = Number(v);
                 switch (filter.type) {
@@ -41,6 +44,15 @@
                         break;
                     case FilterType.Options:
                         filter.options = [];
+                        break;
+                    case FilterType.PF2_Level_Range:
+                        filter.options = [-1, 25];
+                        break;
+                    case FilterType.PF2_Creature_Type:
+                        filter.options = "";
+                        break;
+                    case FilterType.PF2_Trait:
+                        filter.options = "";
                         break;
                 }
             });

--- a/src/builder/stores/filter/EditFilter.svelte
+++ b/src/builder/stores/filter/EditFilter.svelte
@@ -31,7 +31,7 @@
             d.addOption(`${FilterType.Options}`, "Options");
             d.addOption(`${FilterType.Search}`, "Search");
             d.addOption(`${FilterType.PF2_Level_Range}`, "PF2 - Level");
-            d.addOption(`${FilterType.PF2_Creature_Type}`, "PF2 - Monster type");
+            d.addOption(`${FilterType.PF2_Monster_Type}`, "PF2 - Monster type");
             d.addOption(`${FilterType.PF2_Trait}`, "PF2 - Traits");
             d.setValue(`${filter.type}`).onChange((v) => {
                 filter.type = Number(v);
@@ -48,7 +48,7 @@
                     case FilterType.PF2_Level_Range:
                         filter.options = [-1, 25];
                         break;
-                    case FilterType.PF2_Creature_Type:
+                    case FilterType.PF2_Monster_Type:
                         filter.options = "";
                         break;
                     case FilterType.PF2_Trait:

--- a/src/builder/stores/filter/LayoutItemContainer.svelte
+++ b/src/builder/stores/filter/LayoutItemContainer.svelte
@@ -31,7 +31,7 @@
                 return setIcon(node, "sliders-horizontal");
             case FilterType.PF2_Trait:
                 return setIcon(node, "search");
-            case FilterType.PF2_Creature_Type:
+            case FilterType.PF2_Monster_Type:
             return setIcon(node, "search");
         }
 

--- a/src/builder/stores/filter/LayoutItemContainer.svelte
+++ b/src/builder/stores/filter/LayoutItemContainer.svelte
@@ -27,7 +27,14 @@
                 return setIcon(node, "search");
             case FilterType.Options:
                 return setIcon(node, "list");
+            case FilterType.PF2_Level_Range:
+                return setIcon(node, "sliders-horizontal");
+            case FilterType.PF2_Trait:
+                return setIcon(node, "search");
+            case FilterType.PF2_Creature_Type:
+            return setIcon(node, "search");
         }
+
     };
     const edit = (node: HTMLElement) => {
         new ExtraButtonComponent(node).setIcon("pencil");

--- a/src/builder/stores/filter/filter.ts
+++ b/src/builder/stores/filter/filter.ts
@@ -16,7 +16,7 @@ import {
 export enum FilterType {
     Range,
     PF2_Level_Range, 
-    PF2_Creature_Type,
+    PF2_Monster_Type,
     Search,
     Options, 
     PF2_Trait
@@ -37,8 +37,8 @@ interface PF2_Level_RangeFilter extends BaseFilter {
     type: FilterType.PF2_Level_Range;
     options: [number, number];
 }
-interface PF2_Creature_TypeFilter extends BaseFilter {
-    type: FilterType.PF2_Creature_Type;
+interface PF2_Monster_TypeFilter extends BaseFilter {
+    type: FilterType.PF2_Monster_Type;
     options: string;
 }
 interface OptionsFilter extends BaseFilter {
@@ -53,7 +53,7 @@ interface PF2_TraitFilter extends BaseFilter {
     type: FilterType.PF2_Trait;
     options: string;
 }
-export type Filter = RangeFilter | PF2_Level_RangeFilter | OptionsFilter | StringFilter | PF2_TraitFilter | PF2_Creature_TypeFilter;
+export type Filter = RangeFilter | PF2_Level_RangeFilter | OptionsFilter | StringFilter | PF2_TraitFilter | PF2_Monster_TypeFilter;
 export const DEFAULT_NEW_FILTER: Filter = {
     type: FilterType.Search,
     fields: [],
@@ -81,9 +81,9 @@ export interface PF2_Level_RangeFilterStore
     extends BaseFilterStore<PF2_Level_RangeFilter, number | string> {
     type: FilterType.PF2_Level_Range;
 }
-export interface PF2_Creature_TypeFilterStore
-    extends BaseFilterStore<PF2_Creature_TypeFilter, number | string> {
-    type: FilterType.PF2_Creature_Type;
+export interface PF2_Monster_TypeFilterStore
+    extends BaseFilterStore<PF2_Monster_TypeFilter, number | string> {
+    type: FilterType.PF2_Monster_Type;
 }
 export interface OptionsFilterStore
     extends BaseFilterStore<OptionsFilter, number | string> {
@@ -98,7 +98,7 @@ export interface PF2_TraitFilterStore
     type: FilterType.PF2_Trait;
 }
 
-type FilterStore = RangeFilterStore | PF2_Level_RangeFilterStore | OptionsFilterStore | StringFilterStore | PF2_TraitFilterStore | PF2_Creature_TypeFilterStore;
+type FilterStore = RangeFilterStore | PF2_Level_RangeFilterStore | OptionsFilterStore | StringFilterStore | PF2_TraitFilterStore | PF2_Monster_TypeFilterStore;
 
 type FilterFactory<T extends Filter> = (filter: T) => FilterStore;
 
@@ -171,7 +171,7 @@ const createPF2_Level_RangeFilter: FilterFactory<PF2_Level_RangeFilter> = (filte
     };
 };
 
-const createPF2_Creature_TypeFilter: FilterFactory<PF2_Creature_TypeFilter> = (filter) => {
+const createPF2_Monster_TypeFilter: FilterFactory<PF2_Monster_TypeFilter> = (filter) => {
     let DEFAULT_STRING: string = "";
     const store = writable<string>(DEFAULT_STRING);
     const { subscribe, set, update } = store;
@@ -292,8 +292,8 @@ function getFilterStore(filter: Filter) {
             return createRangeFilter(filter);
         case FilterType.PF2_Level_Range:
             return createPF2_Level_RangeFilter(filter);
-        case FilterType.PF2_Creature_Type:
-            return createPF2_Creature_TypeFilter(filter);
+        case FilterType.PF2_Monster_Type:
+            return createPF2_Monster_TypeFilter(filter);
         case FilterType.Search:
             return createStringFilter(filter);
         case FilterType.PF2_Trait:
@@ -379,7 +379,7 @@ function getDerivedFilterOptions(
                             break;
                         }
                         case FilterType.Search:
-                        case FilterType.PF2_Creature_Type:
+                        case FilterType.PF2_Monster_Type:
                         case FilterType.PF2_Trait:
                             continue;
                     }
@@ -619,7 +619,7 @@ export const DEFAULT_FILTERS: Filter[] = [
         derive: true
     },
     {
-        type: FilterType.PF2_Creature_Type,
+        type: FilterType.PF2_Monster_Type,
         text: "Type",
         fields: ["level"],
         options: "",

--- a/src/builder/stores/filter/filter.ts
+++ b/src/builder/stores/filter/filter.ts
@@ -2,7 +2,7 @@ import copy from "fast-copy";
 import type { SRDMonster } from "src/types/creatures";
 import { prepareSimpleSearch, type SearchResult } from "obsidian";
 import type InitiativeTracker from "src/main";
-import { convertFraction } from "src/utils";
+import { convertFraction, PF2LevelToNumber} from "src/utils";
 import { getId } from "src/utils/creature";
 import {
     derived,
@@ -15,8 +15,11 @@ import {
 
 export enum FilterType {
     Range,
+    PF2_Level_Range, 
+    PF2_Creature_Type,
     Search,
-    Options
+    Options, 
+    PF2_Trait
 }
 
 interface BaseFilter {
@@ -30,6 +33,14 @@ interface RangeFilter extends BaseFilter {
     type: FilterType.Range;
     options: [number, number];
 }
+interface PF2_Level_RangeFilter extends BaseFilter {
+    type: FilterType.PF2_Level_Range;
+    options: [number, number];
+}
+interface PF2_Creature_TypeFilter extends BaseFilter {
+    type: FilterType.PF2_Creature_Type;
+    options: string;
+}
 interface OptionsFilter extends BaseFilter {
     type: FilterType.Options;
     options: string[];
@@ -38,7 +49,11 @@ interface StringFilter extends BaseFilter {
     type: FilterType.Search;
     options: string;
 }
-export type Filter = RangeFilter | OptionsFilter | StringFilter;
+interface PF2_TraitFilter extends BaseFilter {
+    type: FilterType.PF2_Trait;
+    options: string;
+}
+export type Filter = RangeFilter | PF2_Level_RangeFilter | OptionsFilter | StringFilter | PF2_TraitFilter | PF2_Creature_TypeFilter;
 export const DEFAULT_NEW_FILTER: Filter = {
     type: FilterType.Search,
     fields: [],
@@ -62,6 +77,14 @@ export interface RangeFilterStore
     extends BaseFilterStore<RangeFilter, number | string> {
     type: FilterType.Range;
 }
+export interface PF2_Level_RangeFilterStore
+    extends BaseFilterStore<PF2_Level_RangeFilter, number | string> {
+    type: FilterType.PF2_Level_Range;
+}
+export interface PF2_Creature_TypeFilterStore
+    extends BaseFilterStore<PF2_Creature_TypeFilter, number | string> {
+    type: FilterType.PF2_Creature_Type;
+}
 export interface OptionsFilterStore
     extends BaseFilterStore<OptionsFilter, number | string> {
     type: FilterType.Options;
@@ -70,8 +93,12 @@ export interface StringFilterStore
     extends BaseFilterStore<StringFilter, number | string> {
     type: FilterType.Search;
 }
+export interface PF2_TraitFilterStore
+    extends BaseFilterStore<PF2_TraitFilter, number | string> {
+    type: FilterType.PF2_Trait;
+}
 
-type FilterStore = RangeFilterStore | OptionsFilterStore | StringFilterStore;
+type FilterStore = RangeFilterStore | PF2_Level_RangeFilterStore | OptionsFilterStore | StringFilterStore | PF2_TraitFilterStore | PF2_Creature_TypeFilterStore;
 
 type FilterFactory<T extends Filter> = (filter: T) => FilterStore;
 
@@ -109,6 +136,67 @@ const createRangeFilter: FilterFactory<RangeFilter> = (filter) => {
     };
 };
 
+
+const createPF2_Level_RangeFilter: FilterFactory<PF2_Level_RangeFilter> = (filter) => {
+    const store = writable<[number, number]>([...filter.options]);
+    const { update, set, subscribe } = store;
+    const isDefault = derived(store, (existing) => {
+        if (
+            filter.options[0] == existing[0] &&
+            filter.options[1] == existing[1]
+        )
+            return true;
+        return false;
+    });
+    return {
+        isDefault,
+        getIsDefault: () => get(isDefault),
+
+        update,
+        set,
+        subscribe,
+
+        reset: () => set([...filter.options]),
+
+        compare: (value: number | string) => {
+            if (get(isDefault)) return true;
+            const values = get(store);
+            return (
+                PF2LevelToNumber(value)[0] >= values[0] &&
+                PF2LevelToNumber(value)[0] <= values[1]
+            );
+        },
+        filter,
+        ...filter
+    };
+};
+
+const createPF2_Creature_TypeFilter: FilterFactory<PF2_Creature_TypeFilter> = (filter) => {
+    let DEFAULT_STRING: string = "";
+    const store = writable<string>(DEFAULT_STRING);
+    const { subscribe, set, update } = store;
+
+    const isDefault = derived(store, (existing) => {
+        return !existing.length;
+    });
+    let search = prepareSimpleSearch("");
+    store.subscribe((value) => (search = prepareSimpleSearch(value)));
+    return {
+        isDefault,
+        getIsDefault: () => get(isDefault),
+        subscribe,
+        set,
+        reset: () => set(DEFAULT_STRING),
+        compare: (value: number | string) => {
+            if (get(isDefault)) return true;
+            if (typeof value === "number") return false;
+            return get(isDefault) || search(PF2LevelToNumber(value)[1]) != null;
+        },
+        update,
+        filter,
+        ...filter
+    };
+};
 function normalize(str: string): string {
     if (typeof str !== "string") return str;
     return str.toLowerCase();
@@ -168,14 +256,48 @@ const createStringFilter: FilterFactory<StringFilter> = (filter) => {
     };
 };
 
+const createPF2_TraitFilter: FilterFactory<PF2_TraitFilter> = (filter) => {
+    let DEFAULT_STRING: string = "";
+    const store = writable<string>(DEFAULT_STRING);
+    const { subscribe, set, update } = store;
+
+    const isDefault = derived(store, (existing) => {
+        return !existing.length;
+    });
+    let search = prepareSimpleSearch("");
+    store.subscribe((value) => (search = prepareSimpleSearch(value)));
+    return {
+        isDefault,
+        getIsDefault: () => get(isDefault),
+        subscribe,
+        set,
+        reset: () => set(DEFAULT_STRING),
+        compare: (value: number | string) => {
+            if (get(isDefault)) return true;
+            if (typeof value === "number") return false;
+            return get(isDefault) || search(value) != null;
+        },
+        update,
+        filter,
+        ...filter
+    };
+};
+
+
 function getFilterStore(filter: Filter) {
     switch (filter.type) {
         case FilterType.Options:
             return createOptionsFilter(filter);
         case FilterType.Range:
             return createRangeFilter(filter);
+        case FilterType.PF2_Level_Range:
+            return createPF2_Level_RangeFilter(filter);
+        case FilterType.PF2_Creature_Type:
+            return createPF2_Creature_TypeFilter(filter);
         case FilterType.Search:
             return createStringFilter(filter);
+        case FilterType.PF2_Trait:
+            return createPF2_TraitFilter(filter);
     }
 }
 export type BuiltFilterStore = ReturnType<typeof createFilterStore>;
@@ -217,6 +339,33 @@ function getDerivedFilterOptions(
                             options.set(filter, new Set(current));
                             break;
                         }
+                        case FilterType.PF2_Level_Range: {
+                            let fieldAsNumber = PF2LevelToNumber(
+                                creature[field]
+                            )[0];
+                            if (fieldAsNumber == null || isNaN(fieldAsNumber))
+                                continue;
+                            const current = [
+                                ...options.get(filter)
+                            ] as number[];
+                            if (!current.length) {
+                                current[0] = Infinity;
+                                current[1] = -Infinity;
+                            }
+                            current[0] = Math.min(current[0], fieldAsNumber);
+                            if (
+                                Math.max(current[1], fieldAsNumber) !=
+                                current[0]
+                            ) {
+                                current[1] = Math.max(
+                                    current[1],
+                                    fieldAsNumber
+                                );
+                            }
+
+                            options.set(filter, new Set(current));
+                            break;
+                        }
                         case FilterType.Options: {
                             if (Array.isArray(creature[field])) {
                                 for (const value of creature[field]) {
@@ -229,9 +378,10 @@ function getDerivedFilterOptions(
                             }
                             break;
                         }
-                        case FilterType.Search: {
+                        case FilterType.Search:
+                        case FilterType.PF2_Creature_Type:
+                        case FilterType.PF2_Trait:
                             continue;
-                        }
                     }
                     continue;
                 }
@@ -307,9 +457,22 @@ export function createFilterStore(
             if (
                 filters.every((filter) => {
                     if (!filter.filter.fields.length) return true;
-                    for (const field of filter.filter.fields) {
-                        if (!(field in creature)) continue;
-                        return filter.compare(creature[field]);
+                    switch (filter.filter.type){
+                        case FilterType.PF2_Trait: {
+                            return Object.keys(creature).some((field) => {
+                                return filter.filter.fields.some((filter_field) =>{
+                                    if(field.startsWith(filter_field + '_')) {
+                                        return filter.compare(creature[field]);
+                                    };
+                            });
+                        });
+                        }
+                        default: {
+                            for (const field of filter.filter.fields) {
+                                if (!(field in creature)) continue;
+                                return filter.compare(creature[field]);
+                            }
+                        }
                     }
                     return true;
                 })
@@ -432,53 +595,58 @@ const NAME_FILTER: StringFilter = {
 
 export const DEFAULT_FILTERS: Filter[] = [
     {
-        type: FilterType.Range,
-        text: "CR",
-        fields: ["cr"],
-        options: [0, 30],
-        id: "ID_DEFAULT_CR_FILTER",
+        type: FilterType.PF2_Level_Range,
+        text: "Level",
+        fields: ["level"],
+        options: [-1, 30],
+        id: "ID_DEFAULT_PF2_LVL_FILTER",
         derive: true
     },
     {
-        type: FilterType.Options,
-        text: "Size",
-        fields: ["size"],
-        options: [],
-        id: "ID_DEFAULT_SIZE_FILTER",
+        type: FilterType.PF2_Trait,
+        text: "Trait",
+        fields: ["trait"],
+        options: "",
+        id: "ID_DEFAULT_PF2_TRAIT_FILTER",
         derive: true
     },
     {
-        type: FilterType.Options,
+        type: FilterType.Search,
+        text: "Source",
+        fields: ["source"],
+        options: "",
+        id: "ID_DEFAULT_PF2_SOURCE_FILTER",
+        derive: true
+    },
+    {
+        type: FilterType.PF2_Creature_Type,
         text: "Type",
-        fields: ["type"],
-        options: [],
-        id: "ID_DEFAULT_TYPE_FILTER",
-        derive: true
-    },
-    {
-        type: FilterType.Options,
-        text: "Alignment",
-        fields: ["alignment"],
-        options: [],
-        id: "ID_DEFAULT_ALIGNMENT_FILTER",
+        fields: ["level"],
+        options: "",
+        id: "ID_DEFAULT_PF2_CREATURE_TYPE_FILTER",
         derive: true
     }
 ];
 
 const ORIGINAL_DEFAULT_LAYOUT: FilterLayout = [
     {
-        nested: [{ id: "ID_DEFAULT_CR_FILTER", type: "filter" }],
-        id: "ID_DEFAULT_NESTED_CR",
-        type: "nested"
+        id: "ID_DEFAULT_LVL_LAYOUT",
+        type: "nested",
+        nested: [{ id: "ID_DEFAULT_PF2_LVL_FILTER", type: "filter" }]
     },
     {
         id: "ID_DEFAULT_NESTED_LAYOUT",
         type: "nested",
         nested: [
-            { id: "ID_DEFAULT_SIZE_FILTER", type: "filter" },
-            { id: "ID_DEFAULT_TYPE_FILTER", type: "filter" },
-            { id: "ID_DEFAULT_ALIGNMENT_FILTER", type: "filter" }
+            { id: "ID_DEFAULT_PF2_TRAIT_FILTER", type: "filter" },
+            { id: "ID_DEFAULT_PF2_SOURCE_FILTER", type: "filter" }
         ]
+        
+    },
+    {
+        id: "ID_DEFAULT_NESTED_LAYOUT_2",
+        type: "nested",
+        nested: [{ id: "ID_DEFAULT_PF2_CREATURE_TYPE_FILTER", type: "filter" }]
     }
 ];
 

--- a/src/builder/stores/table/Headers.svelte
+++ b/src/builder/stores/table/Headers.svelte
@@ -59,8 +59,11 @@
     const icon = (type: SortFunctions) => {
         switch (type) {
             case SortFunctions.LOCAL_COMPARE:
+            case SortFunctions.PF2_TRAIT:
+            case SortFunctions.PF2_TYPE:
                 return SORT_STRING;
             case SortFunctions.CONVERT_FRACTION:
+            case SortFunctions.PF2_LEVEL:
                 return SORT_NUMBER;
             case SortFunctions.CUSTOM:
                 return "function-square";

--- a/src/builder/stores/table/edit-modal.ts
+++ b/src/builder/stores/table/edit-modal.ts
@@ -34,6 +34,9 @@ export class EditModal extends Modal {
             .addDropdown((t) => {
                 t.addOption(`${SortFunctions.LOCAL_COMPARE}`, "String");
                 t.addOption(`${SortFunctions.CONVERT_FRACTION}`, "Number");
+                t.addOption(`${SortFunctions.PF2_LEVEL}`, "PF2 - Level");
+                t.addOption(`${SortFunctions.PF2_TYPE}`, "PF2 - Monster type");
+                t.addOption(`${SortFunctions.PF2_TRAIT}`, "PF2 - Traits");
                 t.addOption(`${SortFunctions.CUSTOM}`, "Custom");
                 t.setValue(`${this.header.type}`).onChange((v) => {
                     this.header.type = Number(v);

--- a/src/builder/stores/table/table.ts
+++ b/src/builder/stores/table/table.ts
@@ -29,6 +29,28 @@ export class TableHeader {
                 return (a: Record<string, any>, b: Record<string, any>) =>
                     (a[this.field] ?? "").localeCompare(b[this.field] ?? "");
             }
+            case SortFunctions.PF_LEVEL: {
+                return (a: Record<string, any>, b: Record<string, any>) => {
+                    const re = /(^[a-zA-Z]+) (\d+)$/gi;
+                    const a_match = a.match(re);
+                    const b_match = b.match(re);
+
+                    if(!a_match && !b_match){
+                        return 0;
+                    } else if (!a_match) {
+                        return 1;
+                    }  else if (!b_match) {
+                        return -1;
+                    } else if(parseInt(a_match[2]) < parseInt(b_match[2])) {
+                        return -1;
+                    } else if (parseInt(a_match[2]) == parseInt(b_match[2])) {
+                        return a_match[1].localCompare(b_match[2]);
+                    } else {
+                        return 1;
+                    }
+                }
+                    
+            }
             case SortFunctions.CONVERT_FRACTION: {
                 return (a: Record<string, any>, b: Record<string, any>) =>
                     convertFraction(a[this.field] ?? 0) -
@@ -73,24 +95,9 @@ export class TableHeader {
 
 export const DEFAULT_HEADERS: TableHeaderState[] = [
     {
-        text: "CR",
-        field: "cr",
-        type: SortFunctions.CONVERT_FRACTION
-    },
-    {
-        text: "Type",
-        field: "type",
-        type: SortFunctions.LOCAL_COMPARE
-    },
-    {
-        text: "Size",
-        field: "size",
-        type: SortFunctions.LOCAL_COMPARE
-    },
-    {
-        text: "Alignment",
-        field: "alignment",
-        type: SortFunctions.LOCAL_COMPARE
+        text: "Level",
+        field: "level",
+        type: SortFunctions.PF_LEVEL
     }
 ];
 

--- a/src/builder/view/creatures/Creature.svelte
+++ b/src/builder/view/creatures/Creature.svelte
@@ -4,10 +4,14 @@
     import { getContext } from "svelte";
     import { encounter } from "../../stores/encounter";
     import Nullable from "../Nullable.svelte";
-    import { convertFraction, DEFAULT_UNDEFINED } from "src/utils";
+    import { convertFraction, DEFAULT_UNDEFINED, PF2LevelToNumber } from "src/utils";
     import { Creature as CreatureCreator } from "src/utils/creature";
-    import type { createTable } from "src/builder/stores/table/table";
+    import type { createTable, TableHeader} from "src/builder/stores/table/table";
+    import {SortFunctions} from "../../builder.types"
     import type InitiativeTracker from "src/main";
+    import Table from "src/tracker/ui/creatures/Table.svelte";
+    import { keyword$DataError } from "ajv/dist/compile/errors";
+    import { _ } from "ajv";
 
     const { players } = encounter;
     const { average } = players;
@@ -31,8 +35,7 @@
         }
         if (property == null) return ``;
         if (typeof property == "string") {
-            const re = /\\?<\w+\\?>/gi;
-            return property.replaceAll(re, '');
+            return property.replaceAll("<STATBLOCK-WIKI-LINK>", '');
         }
         if (typeof property == "number") return `${property}`;
         if (Array.isArray(property)) {
@@ -61,6 +64,23 @@
     function getTooltip(source: string | string[]): string {
         if (!Array.isArray(source)) return "";
         return stringify(source, 0, ", ", false);
+    }
+    function getCreatureField(creature : SRDMonster, header: TableHeader) : string {
+        switch (header.type) {
+            case SortFunctions.PF2_LEVEL:
+                return PF2LevelToNumber(creature[header.field])[0].toString();
+            case SortFunctions.PF2_TYPE:
+                return PF2LevelToNumber(creature[header.field])[1];
+            case SortFunctions.PF2_TRAIT:
+                const traits = Object.keys(creature).filter((key) => {
+                    return key.startsWith(header.field + '_');
+                }).map((key) => creature[key]);
+
+                return stringify(traits, 0, ", ", false);
+            default:
+                return creature[header.field];
+
+        }
     }
 
     $: insignificant =
@@ -115,7 +135,7 @@
         </div>
     </td>
     {#each $table as header}
-        <td><Nullable str={creature[header.field] ?? DEFAULT_UNDEFINED} /></td>
+        <td><Nullable str={getCreatureField(creature, header) ?? DEFAULT_UNDEFINED} /></td>
     {/each}
 </tr>
 

--- a/src/builder/view/creatures/Creature.svelte
+++ b/src/builder/view/creatures/Creature.svelte
@@ -30,7 +30,10 @@
             return "";
         }
         if (property == null) return ``;
-        if (typeof property == "string") return property;
+        if (typeof property == "string") {
+            const re = /\\?<\w+\\?>/gi;
+            return property.replaceAll(re, '');
+        }
         if (typeof property == "number") return `${property}`;
         if (Array.isArray(property)) {
             ret.push(

--- a/src/builder/view/filters/customs/FilterContainer.svelte
+++ b/src/builder/view/filters/customs/FilterContainer.svelte
@@ -5,6 +5,9 @@
         FilterType,
         type LayoutItem,
         type OptionsFilterStore,
+        PF2_Creature_TypeFilterStore,
+        PF2_Level_RangeFilterStore,
+        PF2_TraitFilterStore,
         type RangeFilterStore,
         type StringFilterStore
     } from "src/builder/stores/filter/filter";
@@ -17,7 +20,7 @@
     const { filters } = filterStore;
     export let layout: LayoutItem;
 
-    let filter: RangeFilterStore | OptionsFilterStore | StringFilterStore;
+    let filter: RangeFilterStore | OptionsFilterStore | StringFilterStore | PF2_Level_RangeFilterStore | PF2_TraitFilterStore | PF2_Creature_TypeFilterStore;
     $: {
         if (!("nested" in layout)) {
             filter = $filters.get(layout.id);
@@ -36,10 +39,19 @@
         {#if filter.type == FilterType.Range}
             <Range {filter} />
         {/if}
+        {#if filter.type == FilterType.PF2_Level_Range}
+            <Range {filter} />
+        {/if}
         {#if filter.type == FilterType.Options}
             <Options {filter} />
         {/if}
         {#if filter.type == FilterType.Search}
+            <Search {filter} />
+        {/if}
+        {#if filter.type == FilterType.PF2_Trait}
+            <Search {filter} />
+        {/if}
+        {#if filter.type == FilterType.PF2_Creature_Type}
             <Search {filter} />
         {/if}
     </div>

--- a/src/builder/view/filters/customs/FilterContainer.svelte
+++ b/src/builder/view/filters/customs/FilterContainer.svelte
@@ -5,7 +5,7 @@
         FilterType,
         type LayoutItem,
         type OptionsFilterStore,
-        PF2_Creature_TypeFilterStore,
+        PF2_Monster_TypeFilterStore,
         PF2_Level_RangeFilterStore,
         PF2_TraitFilterStore,
         type RangeFilterStore,
@@ -20,7 +20,7 @@
     const { filters } = filterStore;
     export let layout: LayoutItem;
 
-    let filter: RangeFilterStore | OptionsFilterStore | StringFilterStore | PF2_Level_RangeFilterStore | PF2_TraitFilterStore | PF2_Creature_TypeFilterStore;
+    let filter: RangeFilterStore | OptionsFilterStore | StringFilterStore | PF2_Level_RangeFilterStore | PF2_TraitFilterStore | PF2_Monster_TypeFilterStore;
     $: {
         if (!("nested" in layout)) {
             filter = $filters.get(layout.id);
@@ -51,7 +51,7 @@
         {#if filter.type == FilterType.PF2_Trait}
             <Search {filter} />
         {/if}
-        {#if filter.type == FilterType.PF2_Creature_Type}
+        {#if filter.type == FilterType.PF2_Monster_Type}
             <Search {filter} />
         {/if}
     </div>

--- a/src/builder/view/filters/customs/Range.svelte
+++ b/src/builder/view/filters/customs/Range.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-    import type { RangeFilterStore } from "src/builder/stores/filter/filter";
+    import type { PF2_Level_RangeFilterStore, RangeFilterStore } from "src/builder/stores/filter/filter";
     import Slider from "./Slider.svelte";
 
-    export let filter: RangeFilterStore;
-
+    export let filter: RangeFilterStore|PF2_Level_RangeFilterStore;
     $: min = `Min ${filter.filter.text}`;
     $: max = `Max ${filter.filter.text}`;
 </script>

--- a/src/builder/view/filters/customs/Search.svelte
+++ b/src/builder/view/filters/customs/Search.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { TextComponent, debounce } from "obsidian";
-    import type { StringFilterStore, PF2_TraitFilterStore, PF2_Creature_TypeFilterStore } from "src/builder/stores/filter/filter";
+    import type { StringFilterStore, PF2_TraitFilterStore, PF2_Monster_TypeFilterStore } from "src/builder/stores/filter/filter";
 
-    export let filter: StringFilterStore|PF2_TraitFilterStore|PF2_Creature_TypeFilterStore;
+    export let filter: StringFilterStore|PF2_TraitFilterStore|PF2_Monster_TypeFilterStore;
     const search = (node: HTMLElement) => {
         new TextComponent(node).setPlaceholder(filter.text).onChange(
             debounce((v) => {

--- a/src/builder/view/filters/customs/Search.svelte
+++ b/src/builder/view/filters/customs/Search.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { TextComponent, debounce } from "obsidian";
-    import type { StringFilterStore } from "src/builder/stores/filter/filter";
+    import type { StringFilterStore, PF2_TraitFilterStore, PF2_Creature_TypeFilterStore } from "src/builder/stores/filter/filter";
 
-    export let filter: StringFilterStore;
+    export let filter: StringFilterStore|PF2_TraitFilterStore|PF2_Creature_TypeFilterStore;
     const search = (node: HTMLElement) => {
         new TextComponent(node).setPlaceholder(filter.text).onChange(
             debounce((v) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -39,6 +39,20 @@ export function crToString(cr: string | number): string {
     return str;
 }
 
+export function PF2LevelToNumber(lvl_field: string | number): [number, string] {
+    if (typeof lvl_field == "string") {
+        const type = lvl_field.split(" ")
+                        .slice(0, -1)
+                        .join(" ");
+        const lvl = parseInt(lvl_field.split(" ")
+                             .slice(-1).join(""));
+
+        return [lvl, type];
+    }
+    
+    return [lvl_field, "Creature"];
+}
+
 export function getFromCreatureOrBestiary<T>(
     plugin: InitiativeTracker,
     creature: Creature | SRDMonster,


### PR DESCRIPTION
## Pull Request Description

The encounter builder table is not very useful when dealing with pathfinder 2nd edition (PF2e) monsters. For some reason the export of PF2e monsters as yaml monster stats blocks does not follow the same pattern as DnD 5e monsters. In particular, traits (a system that to my knowledge does not exist in 5e) are not provided in a nice array, but rather with a list of several keys starting by "trait_" and followed by a 2 digits number containing each a single trait. The level is also problematic since it is not provided in a numeric format but rather as a string with the "creature type" coming first followed by level (with a space for separator).

The point of this MR is to implement new filters and column types better suited for PF2e DM. 

## Changes Proposed

Changes in the table part of the encounter builder: 
- [x] New filters:
  + [X] "PF2 - Level" : Slider,, filter on creature level
  + [X] "PF2 - Monster type" : Search field, Filter on monster type (e.g. "Creature", "Hazard", "Army")
  + [X] "PF2 - Trait" : Search field, Filter based on traits (the search in performed accross every traits of the monster)
- [X] New Column headers:
  + [X] "PF2 - Level" : Display the monster level (numeric value, can be used to sort)
  + [X] "PF2 - Monster type" : Display the monster type (string, can be used to sort)
  + [X] "PF2 - Trait" : Display the list of traits separated by commas (string, cannot  be used to sort for now)
- [X] UI: 
  + [X] Update the modify header modal to add the new column types
  + [X] Update the modify filty modal to add the new filters

Notes:
- For "Level" and "Monster type" filter/header, the corresponding column must be "level"
- For "Trait" filter/header, the corresponding column must be "trait" (a column that does not exist, but stands for "trait_XX")


## Related Issues

No relevant issue. 

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [X] I have read the contribution guidelines and code of conduct.
- [X] I have tested the changes locally and they are working as expected.
- [X] I have added appropriate comments and documentation for the code changes.
- [X] My code follows the coding style and standards of this project.
- [X] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully. (didn't see any test)
- [X] I have run linters and fixed any issues.
- [X] I have checked for any potential security issues or vulnerabilities. 

## Screenshots (if applicable)

### The interface with the new column and new filters: 

<img width="883" alt="image" src="https://github.com/user-attachments/assets/b3a67712-9f62-4b17-aef2-28fc430ec712" />

### Sorting on level, trait, and source: 

![image](https://github.com/user-attachments/assets/de03c842-20f8-47ca-8caf-adb360ad5e1d)

Sorting on Monster type: 

![image](https://github.com/user-attachments/assets/60049992-b9d7-4c94-a040-dc5cb693fe4c)

### Create header modal: 

![image](https://github.com/user-attachments/assets/b5d81941-5001-4db2-b663-934a5b90abda)

### Edit Filter Modal:

![image](https://github.com/user-attachments/assets/bb6b677f-5fad-4ab5-b21e-babb1a960c8b)



## Additional Notes
I hope you are interested in this feature even if the plugin seems to focus on 5e conventions. Do not hesitate to tell me if you think some features are missing or need more polishing. 

Thanks in adavance for your review :) 
