### PR TITLE
Fixes the Encounter Builder not loading when using CR2.0 or Flee Mortals XP systems

### DIFF
--- a/src/utils/rpg-system/dnd5e-cr2-simple.ts
+++ b/src/utils/rpg-system/dnd5e-cr2-simple.ts
@@ -68,7 +68,7 @@ const POWER_BY_CR: Record<string, number> = {
 const DIFFICULTY_TO_CSS: Record<string, string> = {
   "Mild": "easy",
   "Bruising": "medium",
-  "Bloddy": "medium",
+  "Bloody": "medium",
   "Brutal": "hard", 
   "Oppressive": "deadly"
 }
@@ -143,12 +143,12 @@ ${thresholdSummary}`;
     const budget: Record<string, number> = {
       mild: 0.4,
       bruising: 0.6,
-      bloddy: 0.75,
+      bloody: 0.75,
       brutal: 0.9,
       Oppressive: 1
     };
 
-    const partyPower = playerLevels.map(x => PLAYER_POWER_BY_LEVEL[x]).reduce((a, b) => a+b)
+    const partyPower = playerLevels.map(x => PLAYER_POWER_BY_LEVEL[x]).reduce((a, b) => a+b, 0)
     return Object.entries(budget)
       .map(([name, value]) => ({
         displayName: (name.charAt(0).toUpperCase() + name.slice(1)),

--- a/src/utils/rpg-system/dnd5e-flee-mortals.ts
+++ b/src/utils/rpg-system/dnd5e-flee-mortals.ts
@@ -100,6 +100,10 @@ export class Dnd5eFleeMortalsRpgSystem extends RpgSystem {
   }
 
   getAveragePlayerLevel(playerLevels: number[]): number {
+    if (playerLevels.length === 0) {
+      return 1;
+    }
+
     const totalPlayerLevelClamped = playerLevels
       .filter((lvl) => lvl && lvl > 0)
       .map((lv) => Math.max(1, Math.min(lv, 20)))


### PR DESCRIPTION
## Pull Request Description

<!-- Briefly describe the purpose of this pull request -->

This fixes issues with the encounter builder and the CR2.0 and Flee Mortals XP systems. 

<!-- List the main changes and features introduced by this pull request -->

- Fixed a bug in Flee Mortals that would result in undefined values when no party was loaded into the encounter builder.
- Fixed a bug in CR2.0 where an invalid function would be called on an empty array when no party was loaded into the encounter builder.
- Fixed the spelling of "Bloody" in the CR2.0 system.

Fixes #309 

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

BEGIN_COMMIT_OVERRIDE
fix: Fixes misspelling of Bloody in CR2.0
fix: Fixes some instances of the encounter builder not loading for some XP systems
END_COMMIT_OVERRIDE