### PR TITLE
Try to return creature's raw XP value if level is not available for PF2E difficulty calc

### DIFF
--- a/src/utils/rpg-system/pf2e.ts
+++ b/src/utils/rpg-system/pf2e.ts
@@ -83,7 +83,7 @@ export class Pathfinder2eRpgSystem extends RpgSystem {
             ?.toString()
             .split(" ")
             .slice(-1);
-        if (lvl == null || lvl == undefined) return 0;
+        if (lvl == null || lvl == undefined) return creature.xp ?? 0;
         const partyLvl = Math.round(
             playerLevels?.length ?? 0 > 0
                 ? playerLevels.reduce((a, b) => a + b) / playerLevels.length


### PR DESCRIPTION


## Pull Request Description

Using pf2e difficulty calculations doesn't work when using inline creatures that specify their XP value. There is no (documented) way to specify level in the inline encounter builder. Since the difficulty logic attempts to use the lvl field to re-derive the xp, an xp/difficulty of "0" is reported for inline-defined creatures.

This change adds an intermediate fallback of returning `creature.xp` if the lvl is unavailable, but still falls back to `0` if `xp` is also undefined/null.

Tradeoff/Downside: These hard-coded XP values don't update against average party level. So e.g. if a user inputs inline XP values based on a party level of 3 and the party levels up to 4, the encounter difficulty & xp budget will be incorrect. This is arguably bad but no worse than the current behavior, which is incorrect or no difficulty ratings ever. The ideal fix for this would be allowing the user to specify a level/cr instead/in-addition to xp, but that's a bigger scope.

## Changes Proposed

<!-- List the main changes and features introduced by this pull request -->

- [ ] Change the `lvl == null` case to return `creature.xp` before returning `0`
- [ ] Thus allowing users to hardcode/override XP values for inline pf2e encounter creatures

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [ ] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [ ] All tests (if applicable) have passed successfully.
- [ ] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Additional Notes

I am not familiar or invested enough in Obsidian plugin development (yet?) to be able to build and test my change locally. This just seemed like it might be more useful and expeditious than submitting an Issue.

<!-- Any additional information or context you want to provide about the pull request -->
