### PR TITLE
feat: add setting to toggle difficulty bar in tracker view

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -161,6 +161,19 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                 );
             });
         new Setting(containerEl)
+            .setName("Display Encounter Difficulty in Tracker")
+            .setDesc(
+                "Display the encounter difficulty bar at the top of the initiative tracker view."
+            )
+            .addToggle((t) => {
+                t.setValue(
+                    this.plugin.data.displayDifficultyInTracker
+                ).onChange(async (v) => {
+                    this.plugin.data.displayDifficultyInTracker = v;
+                    await this.plugin.saveSettings();
+                });
+            });
+        new Setting(containerEl)
             .setName("Roll Equivalent Creatures Together")
             .setDesc(
                 "Equivalent creatures (same Name and AC) will roll the same initiative by default."

--- a/src/settings/settings.types.ts
+++ b/src/settings/settings.types.ts
@@ -7,6 +7,7 @@ import type { BuilderState } from "src/builder/builder.types";
 export interface InitiativeTrackerData {
     beginnerTips: boolean;
     displayDifficulty: boolean;
+    displayDifficultyInTracker: boolean;
     preferStatblockLink: boolean;
     statuses: Condition[];
     unconsciousId: string;

--- a/src/tracker/ui/Metadata.svelte
+++ b/src/tracker/ui/Metadata.svelte
@@ -4,7 +4,7 @@
     import Difficulty from "./Difficulty.svelte";
     import { getRpgSystem } from "src/utils";
 
-    const { state, name, round, party, difficulty } = tracker;
+    const { state, name, round, party, difficulty, data } = tracker;
 
     const plugin = getContext("plugin");
     const rpgSystem = getRpgSystem(plugin);
@@ -23,7 +23,7 @@
             >
         {/if}
     </div>
-    {#if $dif}
+    {#if $dif && $data.displayDifficultyInTracker}
         <Difficulty />
     {/if}
     {#if $party}

--- a/src/tracker/ui/Metadata.svelte
+++ b/src/tracker/ui/Metadata.svelte
@@ -17,7 +17,7 @@
         {#if $name && $name.length}
             <h2 class="initiative-tracker-name">{$name}</h2>
         {/if}
-        {#if $dif?.difficulty?.value > 0}
+        {#if $dif?.difficulty?.value > 0 && $data.displayDifficultyInTracker}
             <span class="initiative-tracker-xp encounter-xp"
                 >{rpgSystem.formatDifficultyValue($dif?.difficulty?.value, true)}</span
             >

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -56,6 +56,7 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
     autoStatus: true,
     beginnerTips: true,
     displayDifficulty: true,
+    displayDifficultyInTracker: true,
     encounters: {},
     warnedAboutImports: false,
     openState: {


### PR DESCRIPTION
Allows hiding the encounter difficulty meter from the sidebar initiative tracker independently of the codeblock renderer's existing "Display Encounter Difficulty" setting. The new "Display Encounter Difficulty in Tracker" toggle now sits directly below "Display Encounter Difficulty" in the settings.

Closes #354